### PR TITLE
Use fhirclient@2 in authorize-client

### DIFF
--- a/authorize-client/index.html
+++ b/authorize-client/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>User Profile</title>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script src="node_modules/fhirclient/fhir-client.js"></script>
+    <script src="node_modules/fhirclient/build/fhir-client.js"></script>
     <script src="app.js"></script>
   </head>
   <body>

--- a/authorize-client/package.json
+++ b/authorize-client/package.json
@@ -5,7 +5,7 @@
     "start": "http-server -p 9090 -c-1"
   },
   "dependencies": {
-    "fhirclient": "^0.1.1",
+    "fhirclient": "^2.3.10",
     "http-server": "^0.10.0"
   }
 }


### PR DESCRIPTION
This makes minimal changes to use `fhirclient@^2.3.10` instead of version `0.1.1`.

My changes to `hasAuthToken` and `clearAuthToken` are effectively using the internals of FHIR-client, and probably require further modification.